### PR TITLE
refactor: simplify policy schema with type-isolated design

### DIFF
--- a/proto/opentelemetry/proto/policy/v1/policy.proto
+++ b/proto/opentelemetry/proto/policy/v1/policy.proto
@@ -10,300 +10,200 @@ option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.policy.v1";
 
 // =============================================================================
-// Core Policy Types
-// =============================================================================
-
-// PolicyType identifies the specific use case for a policy.
-// Policies of the same type can be merged; different types cannot.
-enum PolicyType {
-  POLICY_TYPE_UNSPECIFIED = 0;
-  POLICY_TYPE_LOG_FILTER = 1; // Define how logs are filtered (keep/drop)
-  POLICY_TYPE_REDACTION = 2; // Define data needing redaction/removal
-}
-
-// TelemetryType specifies what kind of telemetry data a policy applies to.
-enum TelemetryType {
-  TELEMETRY_TYPE_UNSPECIFIED = 0;
-  TELEMETRY_TYPE_LOGS = 1;
-}
-
-// =============================================================================
-// Matching
-// =============================================================================
-
-// MatchType specifies the category of telemetry field to match against.
-// Each match type is only valid for certain TelemetryTypes:
-//   - RESOURCE, RESOURCE_ATTRIBUTE, SCOPE, SCOPE_ATTRIBUTE: all telemetry types
-//   - LOG_BODY, LOG_SEVERITY, LOG_ATTRIBUTE: TELEMETRY_TYPE_LOGS only
-//   - METRIC_NAME, METRIC_ATTRIBUTE: TELEMETRY_TYPE_METRICS only (future)
-//   - SPAN_NAME, SPAN_KIND, SPAN_STATUS, SPAN_ATTRIBUTE: TELEMETRY_TYPE_TRACES only (future)
-enum MatchType {
-  MATCH_TYPE_UNSPECIFIED = 0;
-
-  // Resource-level matching (applies to all telemetry types)
-  MATCH_TYPE_RESOURCE_ATTRIBUTE = 1; // Match resource attribute by key (e.g., "service.name")
-
-  // Scope-level matching (applies to all telemetry types)
-  MATCH_TYPE_SCOPE_NAME = 2; // Match instrumentation scope name
-  MATCH_TYPE_SCOPE_VERSION = 3; // Match instrumentation scope version
-  MATCH_TYPE_SCOPE_ATTRIBUTE = 4; // Match scope attribute by key
-
-  // Log-specific matching (requires TELEMETRY_TYPE_LOGS)
-  MATCH_TYPE_LOG_BODY = 10; // Match log body content
-  MATCH_TYPE_LOG_SEVERITY_TEXT = 11; // Match severity text (e.g., "ERROR", "WARN")
-  MATCH_TYPE_LOG_SEVERITY_NUMBER = 12; // Match severity number (1-24)
-  MATCH_TYPE_LOG_ATTRIBUTE = 13; // Match log record attribute by key
-
-  // Metric-specific matching (requires TELEMETRY_TYPE_METRICS - future)
-  MATCH_TYPE_METRIC_NAME = 20; // Match metric name
-  MATCH_TYPE_METRIC_ATTRIBUTE = 21; // Match metric data point attribute by key
-
-  // Trace-specific matching (requires TELEMETRY_TYPE_TRACES - future)
-  MATCH_TYPE_SPAN_NAME = 30; // Match span name
-  MATCH_TYPE_SPAN_KIND = 31; // Match span kind (CLIENT, SERVER, etc.)
-  MATCH_TYPE_SPAN_STATUS = 32; // Match span status code (OK, ERROR, UNSET)
-  MATCH_TYPE_SPAN_ATTRIBUTE = 33; // Match span attribute by key
-}
-
-// Matcher provides a unified way to match against telemetry data using known fields.
+// Common Match Targets
 //
-// IMPORTANT CONSTRAINTS:
-// - Multiple matchers are ANDed together: all matchers must match for the
-//   overall match to succeed.
-// - The match_type must be valid for the policy's telemetry_types. For example,
-//   MATCH_TYPE_LOG_BODY is only valid when TELEMETRY_TYPE_LOGS is in the
-//   policy's telemetry_types list.
-// - The list of matchers should uniquely identify a specific pattern of telemetry
-//   for that policy. Matchers should NOT be used as a catch-all; they should be
-//   specific enough to target the intended telemetry precisely.
+// These targets are shared across telemetry types because Resource and Scope
+// exist at every level of the OTel data model.
+// =============================================================================
+
+// Matches a resource attribute by key (e.g., "service.name").
+message ResourceAttributeTarget {
+  string key = 1;
+}
+
+// Matches the instrumentation scope name.
+message ScopeNameTarget {}
+
+// Matches the instrumentation scope version.
+message ScopeVersionTarget {}
+
+// Matches a scope attribute by key.
+message ScopeAttributeTarget {
+  string key = 1;
+}
+
+// =============================================================================
+// Log Match Targets
+// =============================================================================
+
+// Matches the log body content.
+message LogBodyTarget {}
+
+// Matches the log severity text (e.g., "ERROR", "WARN").
+message LogSeverityTextTarget {}
+
+// Matches the log severity number (1-24).
+message LogSeverityNumberTarget {}
+
+// Matches a log record attribute by key.
+message LogAttributeTarget {
+  string key = 1;
+}
+
+// =============================================================================
+// Log Matcher
+// =============================================================================
+
+// LogMatcher defines a condition for matching logs.
 //
-// The regex uses RE2 syntax for consistency across implementations.
+// Multiple matchers are ANDed: all must match for the policy to apply.
+// Uses RE2 regex syntax. Empty regex matches any value (existence check).
 //
 // Examples:
-//   Match logs from payment service with ERROR severity:
-//     matchers: [
-//       {match_type: RESOURCE_ATTRIBUTE, key: "service.name", regex: "^payment-service$"},
-//       {match_type: LOG_SEVERITY_TEXT, regex: "^ERROR$"}
-//     ]
 //
-//   Match logs containing PII in body from any service in prod:
-//     matchers: [
-//       {match_type: RESOURCE_ATTRIBUTE, key: "deployment.environment", regex: "^prod.*"},
-//       {match_type: LOG_BODY, regex: "\\b[0-9]{3}-[0-9]{2}-[0-9]{4}\\b"}
-//     ]
-message Matcher {
-  // The type of field to match against. Determines which telemetry field
-  // is selected for matching.
-  MatchType match_type = 1;
+//   Match logs from payment service:
+//     {resource_attribute: {key: "service.name"}, regex: "^payment-service$"}
+//
+//   Match ERROR severity:
+//     {severity_text: {}, regex: "^ERROR$"}
+//
+//   Match logs containing SSN pattern:
+//     {body: {}, regex: "\\b[0-9]{3}-[0-9]{2}-[0-9]{4}\\b"}
+message LogMatcher {
+  oneof target {
+    ResourceAttributeTarget resource_attribute = 1;
+    ScopeNameTarget scope_name = 2;
+    ScopeVersionTarget scope_version = 3;
+    ScopeAttributeTarget scope_attribute = 4;
+    LogBodyTarget body = 5;
+    LogSeverityTextTarget severity_text = 6;
+    LogSeverityNumberTarget severity_number = 7;
+    LogAttributeTarget attribute = 8;
+  }
 
-  // Key for attribute-based match types (RESOURCE_ATTRIBUTE, SCOPE_ATTRIBUTE,
-  // LOG_ATTRIBUTE, METRIC_ATTRIBUTE, SPAN_ATTRIBUTE).
-  // For example: "service.name", "http.method", "user.id"
-  // Ignored for non-attribute match types.
-  string key = 2;
-
-  // Regular expression pattern to match the field value against.
-  // Uses RE2 syntax. An empty regex matches any value (existence check).
-  string regex = 3;
-
-  // If true, inverts the match (matches when regex does NOT match)
-  bool negate = 4;
+  string regex = 9;
+  bool negate = 10;
 }
 
 // =============================================================================
-// Policy Type Configurations
+// Log Filter
 // =============================================================================
 
-// FilterAction specifies what to do with matched logs.
 enum FilterAction {
   FILTER_ACTION_UNSPECIFIED = 0;
-  FILTER_ACTION_KEEP = 1; // Keep logs that match
-  FILTER_ACTION_DROP = 2; // Drop logs that match
+  FILTER_ACTION_KEEP = 1;
+  FILTER_ACTION_DROP = 2;
 }
 
-// FilterConfig defines configuration for LOG_FILTER policies.
-// Matches logs based on conditions and keeps or drops them.
-message FilterConfig {
-  // Matchers to identify which logs this filter applies to (AND logic)
-  repeated Matcher matchers = 1;
-
-  // Action to take on matched logs
+// LogFilterConfig keeps or drops logs that match the conditions.
+message LogFilterConfig {
+  repeated LogMatcher matchers = 1;
   FilterAction action = 2;
 }
 
-// RedactionRule defines a single find/replace redaction operation.
-// Similar to sed's s/pattern/replacement/ syntax.
-message RedactionRule {
-  // JSONPath to the field to apply redaction to.
-  // Example: "$.body", "$.attributes.user.email", "$.attributes.*"
-  string path = 1;
+// =============================================================================
+// Log Redaction
+// =============================================================================
 
-  // Regular expression pattern to find (RE2 syntax).
-  // Example: "[0-9]{3}-[0-9]{2}-[0-9]{4}" for SSN
-  // Example: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}" for email
-  string pattern = 2;
-
-  // Replacement string. Supports capture group references ($1, $2, etc.)
-  // Example: "[REDACTED]"
-  // Example: "$1-****-$3" to partially mask
-  // Default: "[REDACTED]"
-  string replacement = 3;
+// LogRedactionTarget specifies which log field to redact.
+message LogRedactionTarget {
+  oneof target {
+    LogBodyTarget body = 1;
+    LogAttributeTarget attribute = 2;
+  }
 }
 
-// RedactionConfig defines configuration for REDACTION policies.
-// Applies sed-like find/replace redaction rules to matched logs.
-message RedactionConfig {
-  // Matchers to identify which logs to apply redaction to (AND logic)
-  // If empty, redaction applies to all logs
-  repeated Matcher matchers = 1;
+// LogRedactionRule defines a find/replace operation.
+message LogRedactionRule {
+  LogRedactionTarget target = 1;
+  string pattern = 2;      // Regex to find (RE2)
+  string replacement = 3;  // Replacement string ($1, $2 supported)
+}
 
-  // Redaction rules to apply (applied in order)
-  repeated RedactionRule rules = 2;
+// LogRedactionConfig scrubs sensitive data from logs.
+message LogRedactionConfig {
+  repeated LogMatcher matchers = 1;  // Scope which logs. Empty = all.
+  repeated LogRedactionRule rules = 2;
 }
 
 // =============================================================================
-// Policy Definition
+// Log Policy
 // =============================================================================
 
-// Policy represents a complete telemetry policy definition.
-// Policies are designed to be:
-// - Typed: Self-identifies its type; same types can merge
-// - Implementation Agnostic: Works in SDK, Collector, or any component
-// - Standalone: No need to understand pipeline configuration
-// - Dynamic: Can be updated post-instantiation
-// - Idempotent: Safe to apply to multiple components
-// - Fail-Open: Does not interfere with telemetry on failure
-//
-// Merge Strategy: Policies of the same type are merged using priority.
-// Higher priority values take precedence when rules conflict.
-message Policy {
-  // Unique identifier for this policy
+// LogPolicy defines how to process logs matching specific conditions.
+message LogPolicy {
   string id = 1;
-
-  // Human-readable name
   string name = 2;
-
-  // Optional description
   string description = 3;
 
-  // The type of policy (must match the config oneof field used)
-  PolicyType policy_type = 4;
-
-  // Telemetry types this policy applies to
-  repeated TelemetryType telemetry_types = 5;
-
-  // Priority for merge conflict resolution (higher = more important)
-  int32 priority = 6;
-
-  // Policy configuration based on policy_type
   oneof config {
-    FilterConfig filter = 7;
-    RedactionConfig redaction = 8;
+    LogFilterConfig filter = 4;
+    LogRedactionConfig redaction = 5;
   }
 
-  // Whether this policy is enabled
-  bool enabled = 9;
-
-  // Metadata labels for organization and filtering
-  repeated opentelemetry.proto.common.v1.KeyValue labels = 10;
-
-  // Timestamp when this policy was created (Unix epoch nanoseconds)
-  fixed64 created_at_unix_nano = 11;
-
-  // Timestamp when this policy was last modified (Unix epoch nanoseconds)
-  fixed64 modified_at_unix_nano = 12;
+  int32 priority = 6;
+  bool enabled = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue labels = 8;
+  fixed64 created_at_unix_nano = 9;
+  fixed64 modified_at_unix_nano = 10;
 }
 
 // =============================================================================
-// Policy Collections and Management
+// Policy Set
 // =============================================================================
 
-// PolicySet represents a collection of policies from a single source/provider.
+// PolicySet is a versioned collection of policies from a single source.
 message PolicySet {
-  // Unique identifier for this policy set
   string id = 1;
-
-  // Human-readable name
   string name = 2;
+  string version = 3;
+  string source = 4;
+  fixed64 timestamp_unix_nano = 5;
 
-  // The policies in this set
-  repeated Policy policies = 3;
-
-  // Version/hash of the entire set (for change detection)
-  string version = 4;
-
-  // Source identifier (which provider supplied this)
-  string source = 5;
-
-  // Timestamp of this policy set (Unix epoch nanoseconds)
-  fixed64 timestamp_unix_nano = 6;
+  repeated LogPolicy log_policies = 6;
+  // repeated MetricPolicy metric_policies = 7;  // future
+  // repeated SpanPolicy span_policies = 8;      // future
 }
 
 // =============================================================================
-// Sync Protocol (for Policy Providers)
+// Sync Protocol
 // =============================================================================
 
-// ClientMetadata contains information about the client requesting policies.
+enum TelemetryType {
+  TELEMETRY_TYPE_UNSPECIFIED = 0;
+  TELEMETRY_TYPE_LOGS = 1;
+  TELEMETRY_TYPE_METRICS = 2;
+  TELEMETRY_TYPE_TRACES = 3;
+}
+
 message ClientMetadata {
-  // Unique identifier for the client instance
   string client_id = 1;
-
-  // Version of the client software
   string client_version = 2;
-
-  // Identifier for the workspace/tenant
   string workspace_id = 3;
-
-  // Last sync timestamp (Unix epoch nanoseconds)
   fixed64 last_sync_timestamp_unix_nano = 4;
-
-  // Policy types this client supports/wants
-  repeated PolicyType supported_policy_types = 5;
-
-  // Telemetry types this client handles
-  repeated TelemetryType supported_telemetry_types = 6;
-
-  // Additional metadata labels
-  repeated opentelemetry.proto.common.v1.KeyValue labels = 7;
-
-  // Resource attributes describing this client's identity
-  repeated opentelemetry.proto.common.v1.KeyValue resource_attributes = 8;
+  repeated TelemetryType supported_telemetry_types = 5;
+  repeated opentelemetry.proto.common.v1.KeyValue labels = 6;
+  repeated opentelemetry.proto.common.v1.KeyValue resource_attributes = 7;
 }
 
-// SyncRequest is sent by clients to request policy updates.
 message SyncRequest {
-  // Client identification and capabilities
   ClientMetadata client_metadata = 1;
-
-  // Request full sync (ignore last_policy_version)
   bool full_sync = 2;
 }
 
-// SyncResponse contains policy updates for the client.
 message SyncResponse {
-  // The complete policy set to apply
   PolicySet policy_set = 1;
-
-  // Timestamp of this sync (Unix epoch nanoseconds)
   fixed64 sync_timestamp_unix_nano = 2;
-
-  // Suggested interval before next sync (in seconds)
   uint32 recommended_sync_interval_seconds = 3;
-
-  // Whether this is a full replacement or incremental update
   bool is_full_sync = 4;
-
-  // Error message if sync failed
   string error_message = 5;
 }
 
 // =============================================================================
-// Policy Provider Service (optional - for gRPC providers)
+// Service
 // =============================================================================
 
-// PolicyService defines the gRPC service for policy providers.
 service PolicyService {
-  // Sync policies with the provider
   rpc Sync(SyncRequest) returns (SyncResponse) {
     option (google.api.http) = {
       post: "/v1/policy/sync"


### PR DESCRIPTION
Simplifies the policy schema. The main changes:

**Isolated by telemetry type.** Instead of a generic `Policy` with a `telemetry_types` field, we now have `LogPolicy` (and future `MetricPolicy`, `SpanPolicy`). Each type owns its matchers, configs, and targets. No field number namespacing, no mixing concerns.

**Matcher targets use oneof with typed messages.** Instead of a `MatchType` enum plus an optional `key` field, each target is its own message. `ResourceAttributeTarget` has a key. `LogBodyTarget` doesn't. Invalid states are unrepresentable.

**Single telemetry type per policy.** We discussed this - start strict, loosen later if needed. The schema now enforces it structurally rather than through documentation.

**Shared targets are shared, specific targets are specific.** `ResourceAttributeTarget` and `ScopeAttributeTarget` will be reused by future `MetricMatcher` and `SpanMatcher`. Log-specific targets like `LogBodyTarget` stay with logs.

**Dropped `PolicyType` enum.** The `oneof config` already tells you whether it's a filter or redaction policy. No redundancy.

The result is ~140 lines, reads top to bottom, and should be straightforward to implement.
