### PR TITLE
feat: add log matcher groups

### DIFF
--- a/proto/tero/policy/v1/log.proto
+++ b/proto/tero/policy/v1/log.proto
@@ -12,8 +12,8 @@ option go_package = "github.com/usetero/policy/gen/go/tero/policy/v1";
 
 // LogTarget defines matching and actions for logs.
 message LogTarget {
-  // Matchers to identify which logs this policy applies to (AND logic).
-  // Implementations MUST reject policies with an empty match list.
+  // Matchers to identify which logs this policy applies to (AND logic). This
+  // is the default matcher group for targets that only need one match surface.
   repeated LogMatcher match = 1;
 
   // The keep field controls whether matching telemetry survives. It unifies
@@ -45,6 +45,26 @@ message LogTarget {
   // Example: sample_key = log_attribute["request_id"] with keep = "10%" means
   // 10% of requests are kept, with all logs from each kept request preserved.
   LogSampleKey sample_key = 4;
+
+  // Alternative matcher groups for targets that can be identified by more than
+  // one stable match surface. Matchers inside each group are ANDed together.
+  // Groups are ORed together with the default match list above.
+  //
+  // Implementations MUST reject policies with no matchers in either match or
+  // match_group. Implementations MUST reject empty matcher groups.
+  repeated LogMatcherGroup match_group = 5;
+}
+
+// LogMatcherGroup defines one alternative log match surface. Matchers inside a
+// group are ANDed together. A LogTarget matches when its default match list
+// matches or any matcher group matches.
+message LogMatcherGroup {
+  // Optional human-readable name for this match surface.
+  string name = 1;
+
+  // Matchers in this group (AND logic). Implementations MUST reject empty
+  // matcher groups.
+  repeated LogMatcher match = 2;
 }
 
 // LogSampleKey specifies which field to use as the sampling key for consistent

--- a/spec.md
+++ b/spec.md
@@ -84,19 +84,38 @@ The `log` target defines matching criteria and actions for log records.
 
 ```
 LogTarget {
-  match:     LogMatcher[]   // REQUIRED, at least one matcher
-  keep:      string         // OPTIONAL, defaults to "all"
-  transform: LogTransform   // OPTIONAL
+  match:       LogMatcher[]       // OPTIONAL default matcher group
+  match_group: LogMatcherGroup[]  // OPTIONAL alternative matcher groups
+  keep:        string             // OPTIONAL, defaults to "all"
+  transform:   LogTransform       // OPTIONAL
 }
 ```
 
-A log target MUST contain at least one matcher. A log target MUST specify either
-a `keep` value other than `"all"` or a `transform`, or both.
+A log target MUST contain at least one matcher in `match` or `match_group`. A
+log target MUST specify either a `keep` value other than `"all"` or a
+`transform`, or both.
 
 ### Log Matching
 
-Matchers identify which log records a policy applies to. Multiple matchers are
-combined with AND logic: all matchers MUST match for the policy to apply.
+Matchers identify which log records a policy applies to. The `match` field is
+the default matcher group and uses AND logic: all matchers MUST match for the
+policy to apply.
+
+`match_group` defines alternative match surfaces for the same policy. Matchers
+inside a group use AND logic. Groups use OR logic. A log target matches when the
+default `match` group matches or any `match_group` matches.
+
+Implementations MUST reject empty matcher groups. Implementations MUST reject a
+log target with no matchers in either `match` or `match_group`.
+
+#### LogMatcherGroup Structure
+
+```
+LogMatcherGroup {
+  name:  string        // OPTIONAL, human-readable match surface name
+  match: LogMatcher[]  // REQUIRED, at least one matcher
+}
+```
 
 #### LogMatcher Structure
 
@@ -884,6 +903,28 @@ log:
       - log_attribute: ["http", "request", "headers", "authorization"]
         regex: '(?i)^(bearer\s+).+$'
         replacement: "$1[REDACTED]"
+```
+
+Example with alternative log match surfaces:
+
+```yaml
+id: drop-health-check-access-logs
+name: Drop health check access logs
+log:
+  match_group:
+    - name: body-template
+      match:
+        - log_field: LOG_FIELD_BODY
+          regex: '^GET /healthz .* 200 '
+    - name: structured-http
+      match:
+        - log_attribute: ["http", "request", "method"]
+          exact: GET
+        - log_attribute: ["url", "path"]
+          exact: /healthz
+        - log_attribute: ["http", "response", "status_code"]
+          exact: "200"
+  keep: none
 ```
 
 Example metric policy:


### PR DESCRIPTION
## Why

The control plane can produce a single logical log event with multiple stable match surfaces. For example, the same event may be identifiable by a body/template matcher or by structured HTTP attributes.

The current `LogTarget.match` field only supports a flat AND list. That cannot represent `(A AND B) OR (C AND D)` without either rejecting the event or flattening alternatives into an incorrect matcher that requires every surface to match at once.

## What changed

- Adds `LogMatcherGroup` to represent one alternative log match surface.
- Adds `LogTarget.match_group` for OR alternatives.
- Defines the semantics explicitly:
  - `match` remains the default AND matcher group.
  - matchers inside each `match_group` are ANDed.
  - groups are ORed with the default `match` group.
- Updates the policy spec with structure, validation rules, and a YAML example.

This is an additive proto change and preserves the existing simple `match` shape for policies that only need one match surface.

## Validation

- `./bin/task do`
- `./bin/task breaking`
